### PR TITLE
Remove "if" condition 

### DIFF
--- a/.github/workflows/OrangeFox-Compile.yml
+++ b/.github/workflows/OrangeFox-Compile.yml
@@ -47,7 +47,6 @@ jobs:
   build:
     name: Build OFR by ${{ github.actor }}
     runs-on: ubuntu-latest
-    if: github.event.repository.owner.id == github.event.sender.id
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:


### PR DESCRIPTION
Is this necessary? It causes the job be skipped when run in an organization

![Screenshot_2024-05-20-11-36-45-228-edit_com android chrome](https://github.com/carlodandan/OrangeFox-Action-Builder/assets/103020425/2f9c3ea9-370f-4ffe-aa79-43dc9c4372b9)
