### PR TITLE
builder: Switch job runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/OrangeFox-Compile.yml
+++ b/.github/workflows/OrangeFox-Compile.yml
@@ -46,7 +46,7 @@ on:
 jobs:
   build:
     name: Build OFR by ${{ github.actor }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:


### PR DESCRIPTION
Hello! As ubuntu-latest has changed to 24.04 LTS, it is necessary to switch the runner to ubuntu-22.04 to maintain compatibility.